### PR TITLE
fix: workflow call tagging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ on:
             version_format:
                 type: string
                 description: Version format to use for tagging
-                default: "${major}.${minor}.${patch}-${{ inputs.environment }}"
+                required: false
 
 env:
   SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}


### PR DESCRIPTION
# Description

Remove default version in workflow call allowing to use DEFAULT_VERSION_FORMAT: '${major}.${minor}.${patch}-${{ inputs.environment }}' for higher env tags


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

## Additional Notes:

Please add any other context about the pull request here.
